### PR TITLE
Revise transfer endpoint documentation for v4 usage

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -894,8 +894,8 @@ Get withdraw address whitelist for the user.
 #### Transfers (USER_DATA)
 
 ```shell
-POST /openapi/transfer/v3/transfers (Legacy)
 POST /openapi/transfer/v4/transfers
+POST /openapi/transfer/v3/transfers (Legacy)
 ```
 
 This endpoint is used to transfer funds between two accounts.


### PR DESCRIPTION
Updated API documentation to recommend using v4 for new integrations.